### PR TITLE
Update agentThreadInfo type and downgrade target framework

### DIFF
--- a/AzureAgentToM365ATK/Agents/AzureAgent.cs
+++ b/AzureAgentToM365ATK/Agents/AzureAgent.cs
@@ -192,7 +192,7 @@ public class AzureAgent : AgentApplication
     private static AgentThread GetConversationThread(AIAgent agent, ITurnState turnState)
     {
         AgentThread thread;
-        string? agentThreadInfo = turnState.Conversation.GetValue<string?>("conversation.threadInfo", () => null);
+        string agentThreadInfo = turnState.Conversation.GetValue<string>("conversation.threadInfo", () => null);
         if (string.IsNullOrEmpty(agentThreadInfo))
         {
             thread = agent.GetNewThread();

--- a/AzureAgentToM365ATK/AzureAgentToM365ATK.csproj
+++ b/AzureAgentToM365ATK/AzureAgentToM365ATK.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);SKEXP0110;SKEXP0010</NoWarn>


### PR DESCRIPTION
Modified the `AzureAgent` class to change `agentThreadInfo` from a nullable string (`string?`) to a non-nullable string (`string`) for improved type safety.

Downgraded the target framework in `AzureAgentToM365ATK.csproj` from `net9.0` to `net8.0` to ensure compatibility with environments that do not yet support .NET 9.0.